### PR TITLE
Enable runscript command in production environment

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -102,6 +102,7 @@ THIRD_PARTY_APPS = [
     "health_check.contrib.celery",
     "health_check.contrib.celery_ping",
     "solo",
+    "django_extensions",  # https://django-extensions.readthedocs.io/en/latest/installation_instructions.html#configuration
 ]
 
 LOCAL_APPS = [

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -63,10 +63,6 @@ if env("USE_DOCKER") == "yes":
     hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
     INTERNAL_IPS += [".".join(ip.split(".")[:-1] + ["1"]) for ip in ips]
 
-# django-extensions
-# ------------------------------------------------------------------------------
-# https://django-extensions.readthedocs.io/en/latest/installation_instructions.html#configuration
-INSTALLED_APPS += ["django_extensions"]  # noqa: F405
 # Celery
 # ------------------------------------------------------------------------------
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -57,3 +57,6 @@ django-unfold==0.59.0  # https://pypi.org/project/django-unfold/
 
 # PostgreSQL Vector Extension
 pgvector==0.4.1  # https://pypi.org/project/pgvector/
+
+# Django Extensions (needed for runscript command)
+django-extensions==3.2.3  # https://github.com/django-extensions/django-extensions

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -34,6 +34,5 @@ pre-commit==4.2.0  # https://github.com/pre-commit/pre-commit
 factory-boy==3.3.3  # https://github.com/FactoryBoy/factory_boy
 
 django-debug-toolbar==5.1.0  # https://github.com/jazzband/django-debug-toolbar
-django-extensions==3.2.3  # https://github.com/django-extensions/django-extensions
 django-coverage-plugin==3.1.0  # https://github.com/nedbat/django_coverage_plugin
 pytest-django==4.10.0  # https://github.com/pytest-dev/pytest-django


### PR DESCRIPTION
## Summary
• Move django-extensions from local-only to base requirements to enable runscript command in production
• Add django_extensions to base INSTALLED_APPS instead of local-only settings
• Remove duplicate django_extensions configuration from local settings

## Test plan
- [x] Verify django-extensions is available in base requirements
- [x] Confirm django_extensions app is registered in base settings
- [ ] Test runscript command works in production Docker container
- [ ] Verify existing development functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added django-extensions as a core dependency and included it in the main settings.
  * Removed duplicate django-extensions configuration and dependency from local settings and requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->